### PR TITLE
small fix in ImageGeneticAdversarialGeneratorLatent generator

### DIFF
--- a/externals/ABELE/ilore/ineighgen.py
+++ b/externals/ABELE/ilore/ineighgen.py
@@ -240,8 +240,7 @@ class ImageGeneticAdversarialGeneratorLatent(ImageAdversarialGeneratorLatent):
         # print(Yb[:5])
 
         # lZ_img, Z_img, Yb = self._fix_neigh(lZ_img, Z_img, Yb, class_value)
-
-        Z = np.array(lZ_img)
+        
         if self.scale:
             scaler = MinMaxScaler()
             Z = scaler.fit_transform(Z)


### PR DESCRIPTION
While experimenting ABELE explainer I found this potential issue in the ImageGeneticAdversarialGeneratorLatent generator. After the generation balancing made by the _balance_neigh method, in the attempt to adjust the Z array type, this line overrides it with the former array (before balancing). It creates problems when the balance _balance_neigh adds new samples to balance the generation.

I believe this line would only make sense with the line `# lZ_img, Z_img, Yb = self._fix_neigh(lZ_img, Z_img, Yb, class_value)` uncommented.

What do you think?