### PR TITLE
Pytorch compatibility

### DIFF
--- a/src/xailib/models/pytorch_classifier_wrapper.py
+++ b/src/xailib/models/pytorch_classifier_wrapper.py
@@ -1,0 +1,39 @@
+from xailib.models.bbox import AbstractBBox
+import torch
+import numpy as np
+
+class pytorch_classifier_wrapper(AbstractBBox):
+    def __init__(self, classifier, device = "cpu"):
+        super().__init__()
+        self.bbox = classifier
+        self.device = device
+
+    def model(self):
+        return self.bbox
+
+    def prepare_input(self, X):
+        if isinstance(X, np.ndarray):
+            X = torch.from_numpy(X)
+        X = X.to(self.device)
+
+        return X
+
+    def predict(self, X):
+        X = self.prepare_input(X)
+
+        with torch.no_grad():
+            y = self.bbox(X)
+            y = torch.argmax(y, dim=-1)
+
+            y = y.cpu().numpy()
+
+            return y
+
+    def predict_proba(self, X):
+        X = self.prepare_input(X)
+
+        with torch.no_grad():
+            y = self.bbox(X)
+            y = y.cpu().numpy()
+
+            return y

--- a/src/xailib/models/pytorch_classifier_wrapper.py
+++ b/src/xailib/models/pytorch_classifier_wrapper.py
@@ -3,7 +3,15 @@ import torch
 import numpy as np
 
 class pytorch_classifier_wrapper(AbstractBBox):
-    def __init__(self, classifier, device = "cpu", n_features = None):
+    """ Wrapper for a Pytorch classifier to be used as a BBox.
+
+    Args:
+        classifier: Pytorch model.
+        device: Optional, string indicating the device to use, either "cpu" or "cuda". Default is "cpu".
+        n_features: Optional, integer indicating the number of features for reshaping the input. Default is 1.
+    """
+
+    def __init__(self, classifier, device = "cpu", n_features = 1):
         super().__init__()
         self.bbox = classifier
         self.device = device
@@ -13,6 +21,15 @@ class pytorch_classifier_wrapper(AbstractBBox):
         return self.bbox
 
     def prepare_input(self, X):
+        r""" Converts input data to a PyTorch tensor suitable for model inference.
+
+        Args:
+            X: Input data, either a numpy array or a PyTorch tensor.
+
+        Returns:
+            torch.Tensor: The input data as a float tensor, reshaped to (-1, n_features) if n_features is set,
+            and moved to the specified device (CPU or CUDA).
+        """
         if isinstance(X, np.ndarray):
             X = torch.from_numpy(X)
 


### PR DESCRIPTION
This PR introduces support for using PyTorch models within the library.

To do so, I create a `pytorch_classifier_wrapper.py` file similarly to the ones already found in the library. With two particularities in the `__init__` method:

- An optional parameter `device`, that allows to use models within the GPU.
- A parameter `features` to reshape the input correctly. 